### PR TITLE
Add link to VWC Extension pack in the VS Code Extension marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Being able to code well requires you to be able to use your machine well. We're 
 
 ### Code Editor
 
-VS Code is our primary text editor and is **MANDATORY**. Download it [here](https://code.visualstudio.com/download) and play around with it to become familiar since you will spend many hours in this environment!
+VS Code is our primary text editor and is **MANDATORY**. Download it [here](https://code.visualstudio.com/download) and play around with it to become familiar since you will spend many hours in this environment!  To help with setup, we have created an extension pack that will get you all of the extensions you will need to handle all of the different formats and configurations during your cohort coursework.  It is available [here](https://marketplace.visualstudio.com/items?itemName=VetsWhoCode.vetswhocode-extension-pack).
 
 ### Command Line Interface
 


### PR DESCRIPTION
I added a link to the VWC Extension pack to the prework README so that the next cohort will be able to access it by reading through the prework documentation.  Hopefully this is helpful in the future and eliminates the need for us to remember to tell them the pack exists.